### PR TITLE
Support for different target platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ GPIOs are handled by direct register manipulation for faster performance. *This 
 
 This driver needs **[libopencm3](https://github.com/libopencm3/libopencm3.git)** library. The library is provided with this repository. You may get the latest version of libopencm3 from [here](https://github.com/libopencm3/libopencm3.git), but that may or may not work depending on the changes made in libopencm3 latest version.
 
+In order to be able to program smt32 devices [st-flash is needed](https://github.com/stlink-org/stlink/blob/master/doc/man/st-flash.md)
+
 ### Download
 Download this repository using [git](https://git-scm.com/):
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ GPIOs are handled by direct register manipulation for faster performance. *This 
 
 This driver needs **[libopencm3](https://github.com/libopencm3/libopencm3.git)** library. The library is provided with this repository. You may get the latest version of libopencm3 from [here](https://github.com/libopencm3/libopencm3.git), but that may or may not work depending on the changes made in libopencm3 latest version.
 
-In order to be able to program smt32 devices [st-flash is needed](https://github.com/stlink-org/stlink/blob/master/doc/man/st-flash.md)
+In order to be able to program smt32 devices [st-flash](https://github.com/stlink-org/stlink/blob/master/doc/man/st-flash.md) is needed.
 
 ### Download
 Download this repository using [git](https://git-scm.com/):

--- a/example/Makefile
+++ b/example/Makefile
@@ -41,7 +41,10 @@ CFLAGS += -mlittle-endian -mthumb -mthumb-interwork
 CFLAGS += -mfloat-abi=soft
 CFLAGS += --specs=nano.specs
 CFLAGS += $(MCFLAGS)
-	
+
+################ Target Platform Flags (uncomment one) ######################
+CFLAGS += -DUSER_DEFAULT_PLATFORM		# Default example from the repository
+#CFLAGS += -DDSO138_PLATFORM		    # DSO138 oscilloscope (jyetech.com/dso-138-oscilloscope-diy-kit/)
 
 ############# CFLAGS for Optimization ##################
 CFLAGS += -O0

--- a/example/Makefile
+++ b/example/Makefile
@@ -4,8 +4,9 @@
 
 TARGET=main
 
-
-TOOLCHAIN_PREFIX=~/Toolchains/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux/gcc-arm-none-eabi-9-2019-q4-major/bin/arm-none-eabi
+# Uncomment needed toolchain configuration line
+#TOOLCHAIN_PREFIX=~/Toolchains/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux/gcc-arm-none-eabi-9-2019-q4-major/bin/arm-none-eabi
+TOOLCHAIN_PREFIX=arm-none-eabi
 
 CC=$(TOOLCHAIN_PREFIX)-gcc
 LD=$(TOOLCHAIN_PREFIX)-gcc
@@ -60,8 +61,7 @@ LFLAGS += -nostartfiles #We're using no start file. Without this flag, get linke
 
 ################### Recipe to make all (build and burn) ####################
 .PHONY: all
-all: build burn
-
+all: build
 
 ################### Recipe to build ####################
 .PHONY: build

--- a/example/main.c
+++ b/example/main.c
@@ -51,7 +51,12 @@ int main(void)
 	//initializing the ili9341 display driver
 	ili_init();
 	//rotating display to potrait mode
+
+#ifdef USER_DEFAULT_PLATFORM
 	ili_rotate_display(1);
+#elif DSO138_PLATFORM
+    ili_rotate_display(0);
+#endif
 
 	// Fiiling the entire screen with cyan color
 	ili_fill_screen(ILI_COLOR_CYAN);
@@ -73,7 +78,7 @@ int main(void)
 
 	// Draw a "thicc" line
 	ili_draw_line(180, 2, 20, 250, 5, ILI_COLOR_BLUE);
-	
+
 	// Draw some individual pixels in random points
 	for (uint16_t i = 0; i < 1000; i++)
 		ili_draw_pixel(rand() % 100 + 120, rand() % 100 + 60, ILI_COLOR_WHITE + rand() % 100 + 60);

--- a/ili9341_stm32_parallel8.c
+++ b/ili9341_stm32_parallel8.c
@@ -401,7 +401,7 @@ void ili_draw_rectangle(uint16_t x, uint16_t y, uint16_t w, uint16_t h, uint16_t
 	ili_draw_fast_h_line(x, y+h, x+w-1, y+h-1, 1, color);
 	ili_draw_fast_v_line(x, y, x-1, y+h-1, 1, color);
 	ili_draw_fast_v_line(x+w, y, x+w-1, y+h-1, 1, color);
-	 
+
 
 }
 
@@ -604,31 +604,40 @@ void ili_rotate_display(uint8_t rotation)
 	* 					2 : Landscape 2
 	* 					3 : Potrait 2
 	*/
+
+#ifdef USER_DEFAULT_PLATFORM
+    uint16_t new_height = 240;
+    uint16_t new_width = 320;
+#elif DSO138_PLATFORM
+    uint16_t new_height = 320;
+    uint16_t new_width = 240;
+#endif
+
 	switch (rotation)
 	{
 		case 0:
 			write_command_8bit(ILI_MADCTL);		//Memory Access Control
 			write_data_8bit(0x40);				//MX: 1, MY: 0, MV: 0	(Landscape 1. Default)
-			ili_tftheight = 240;
-			ili_tftwidth = 320;
+			ili_tftheight = new_height;
+			ili_tftwidth = new_width;
 			break;
 		case 1:
 			write_command_8bit(ILI_MADCTL);		//Memory Access Control
 			write_data_8bit(0x20);				//MX: 0, MY: 0, MV: 1	(Potrait 1)
-			ili_tftheight = 320;
-			ili_tftwidth = 240;
+			ili_tftheight = new_width;
+			ili_tftwidth = new_height;
 			break;
 		case 2:
 			write_command_8bit(ILI_MADCTL);		//Memory Access Control
 			write_data_8bit(0x80);				//MX: 0, MY: 1, MV: 0	(Landscape 2)
-			ili_tftheight = 240;
-			ili_tftwidth = 320;
+			ili_tftheight = new_height;
+			ili_tftwidth = new_width;
 			break;
 		case 3:
 			write_command_8bit(ILI_MADCTL);		//Memory Access Control
 			write_data_8bit(0xE0);				//MX: 1, MY: 1, MV: 1	(Potrait 2)
-			ili_tftheight = 320;
-			ili_tftwidth = 240;
+			ili_tftheight = new_width;
+			ili_tftwidth = new_height;
 			break;
 	}
 }
@@ -648,7 +657,7 @@ void ili_init()
 	RST_IDLE;
 	RST_ACTIVE;
 	RST_IDLE;
-	
+
 	// Approx 10ms delay at 128MHz clock
 	for (uint32_t i = 0; i < 2000000; i++)
 		__asm__("nop");

--- a/ili9341_stm32_parallel8.h
+++ b/ili9341_stm32_parallel8.h
@@ -126,6 +126,10 @@ SOFTWARE.
  * D/Cn					PB5#include <libopencm3/stm32/rcc.h>
  * WRn					PB4
  * RDn					PB3
+ *
+ * >>>>>>>>>>>> ATTENTION: if there are other ports in use, e.g. GPIOC,
+ * >>>>>>>>>>>> please, update CONFIG_GPIO_CLOCK() and CONFIG_GPIO()
+ * >>>>>>>>>>>> macros below accordingly.
  */
 #define ILI_PORT_DATA	GPIOA
 #define DATA_0			GPIO0
@@ -151,6 +155,7 @@ AFIO_MAPR_SWJ_CFG_FULL_SWJ_NO_JNTRST:  Full Serial Wire JTAG capability without 
 AFIO_MAPR_SWJ_CFG_JTAG_OFF_SW_ON: JTAG-DP disabled with SW-DP enabled
 AFIO_MAPR_SWJ_CFG_JTAG_OFF_SW_OFF: JTAG-DP disabled and SW-DP disabled
 */
+
 /******* Pin confirugation END (no changes are needed below this line) *******/
 
 #define RD_ACTIVE		GPIO_BRR(ILI_PORT_CTRL) = ILI_RD

--- a/ili9341_stm32_parallel8.h
+++ b/ili9341_stm32_parallel8.h
@@ -87,26 +87,54 @@ SOFTWARE.
 #define ILI_PWCTR6  0xFC
 */
 
-// Color definitions
-#define ILI_COLOR_BLACK       0x0000  ///<   0,   0,   0
-#define ILI_COLOR_NAVY        0x000F  ///<   0,   0, 123
-#define ILI_COLOR_DARKGREEN   0x03E0  ///<   0, 125,   0
-#define ILI_COLOR_DARKCYAN    0x03EF  ///<   0, 125, 123
-#define ILI_COLOR_MAROON      0x7800  ///< 123,   0,   0
-#define ILI_COLOR_PURPLE      0x780F  ///< 123,   0, 123
-#define ILI_COLOR_OLIVE       0x7BE0  ///< 123, 125,   0
-#define ILI_COLOR_LIGHTGREY   0xC618  ///< 198, 195, 198
-#define ILI_COLOR_DARKGREY    0x7BEF  ///< 123, 125, 123
-#define ILI_COLOR_BLUE        0x001F  ///<   0,   0, 255
-#define ILI_COLOR_GREEN       0x07E0  ///<   0, 255,   0
-#define ILI_COLOR_CYAN        0x07FF  ///<   0, 255, 255
-#define ILI_COLOR_RED         0xF800  ///< 255,   0,   0
-#define ILI_COLOR_MAGENTA     0xF81F  ///< 255,   0, 255
-#define ILI_COLOR_YELLOW      0xFFE0  ///< 255, 255,   0
-#define ILI_COLOR_WHITE       0xFFFF  ///< 255, 255, 255
-#define ILI_COLOR_ORANGE      0xFD20  ///< 255, 165,   0
-#define ILI_COLOR_GREENYELLOW 0xAFE5  ///< 173, 255,  41
-#define ILI_COLOR_PINK        0xFC18  ///< 255, 130, 198
+#ifdef USER_DEFAULT_PLATFORM
+    // Color definitions
+    #define ILI_COLOR_BLACK       0x0000  ///<   0,   0,   0
+    #define ILI_COLOR_NAVY        0x000F  ///<   0,   0, 123
+    #define ILI_COLOR_DARKGREEN   0x03E0  ///<   0, 125,   0
+    #define ILI_COLOR_DARKCYAN    0x03EF  ///<   0, 125, 123
+    #define ILI_COLOR_MAROON      0x7800  ///< 123,   0,   0
+    #define ILI_COLOR_PURPLE      0x780F  ///< 123,   0, 123
+    #define ILI_COLOR_OLIVE       0x7BE0  ///< 123, 125,   0
+    #define ILI_COLOR_LIGHTGREY   0xC618  ///< 198, 195, 198
+    #define ILI_COLOR_DARKGREY    0x7BEF  ///< 123, 125, 123
+    #define ILI_COLOR_BLUE        0x001F  ///<   0,   0, 255
+    #define ILI_COLOR_GREEN       0x07E0  ///<   0, 255,   0
+    #define ILI_COLOR_CYAN        0x07FF  ///<   0, 255, 255
+    #define ILI_COLOR_RED         0xF800  ///< 255,   0,   0
+    #define ILI_COLOR_MAGENTA     0xF81F  ///< 255,   0, 255
+    #define ILI_COLOR_YELLOW      0xFFE0  ///< 255, 255,   0
+    #define ILI_COLOR_WHITE       0xFFFF  ///< 255, 255, 255
+    #define ILI_COLOR_ORANGE      0xFD20  ///< 255, 165,   0
+    #define ILI_COLOR_GREENYELLOW 0xAFE5  ///< 173, 255,  41
+    #define ILI_COLOR_PINK        0xFC18  ///< 255, 130, 198
+
+#elif DSO138_PLATFORM
+    #define	RB 0  // Red bits position
+    #define	GB 5  // Green bits position
+    #define	BB 11 // Blue bits position
+    #define	RGB(R,G,B) (((R >> 3) << RB) | ((G >> 2) << GB) | ((B >> 3) << BB))
+
+    #define ILI_COLOR_BLACK       RGB(0,     0,   0)
+    #define ILI_COLOR_NAVY        RGB(0,     0, 123)
+    #define ILI_COLOR_DARKGREEN   RGB(0,   125,   0)
+    #define ILI_COLOR_DARKCYAN    RGB(0,   125, 123)
+    #define ILI_COLOR_MAROON      RGB(123,   0,   0)
+    #define ILI_COLOR_PURPLE      RGB(123,   0, 123)
+    #define ILI_COLOR_OLIVE       RGB(123, 125,   0)
+    #define ILI_COLOR_LIGHTGREY   RGB(198, 195, 198)
+    #define ILI_COLOR_DARKGREY    RGB(123, 125, 123)
+    #define ILI_COLOR_BLUE        RGB(0,     0, 255)
+    #define ILI_COLOR_GREEN       RGB(0,   255,   0)
+    #define ILI_COLOR_CYAN        RGB(0,   255, 255)
+    #define ILI_COLOR_RED         RGB(255,   0,   0)
+    #define ILI_COLOR_MAGENTA     RGB(255,   0, 255)
+    #define ILI_COLOR_YELLOW      RGB(255, 255,   0)
+    #define ILI_COLOR_WHITE       RGB(255, 255, 255)
+    #define ILI_COLOR_ORANGE      RGB(255, 165,   0)
+    #define ILI_COLOR_GREENYELLOW RGB(173, 255,  41)
+    #define ILI_COLOR_PINK        RGB(255, 130, 198)
+#endif
 
 /*************************** Pin confirugation START ************************/
 #ifdef USER_DEFAULT_PLATFORM

--- a/ili9341_stm32_parallel8.h
+++ b/ili9341_stm32_parallel8.h
@@ -110,30 +110,42 @@ SOFTWARE.
     #define ILI_COLOR_PINK        0xFC18  ///< 255, 130, 198
 
 #elif DSO138_PLATFORM
-    #define	RB 0  // Red bits position
-    #define	GB 5  // Green bits position
-    #define	BB 11 // Blue bits position
-    #define	RGB(R,G,B) (((R >> 3) << RB) | ((G >> 2) << GB) | ((B >> 3) << BB))
+    #define	R_POS_RGB	11	// Red last bit position for RGB display
+    #define	G_POS_RGB	5 	// Green last bit position for RGB display
+    #define	B_POS_RGB   0	// Blue last bit position for RGB display
+    #define	RGB(R,G,B) \
+        (((uint16_t)(R >> 3) << R_POS_RGB) | \
+         ((uint16_t)(G >> 2) << G_POS_RGB) | \
+         ((uint16_t)(B >> 3) << B_POS_RGB))
 
-    #define ILI_COLOR_BLACK       RGB(0,     0,   0)
-    #define ILI_COLOR_NAVY        RGB(0,     0, 123)
-    #define ILI_COLOR_DARKGREEN   RGB(0,   125,   0)
-    #define ILI_COLOR_DARKCYAN    RGB(0,   125, 123)
-    #define ILI_COLOR_MAROON      RGB(123,   0,   0)
-    #define ILI_COLOR_PURPLE      RGB(123,   0, 123)
-    #define ILI_COLOR_OLIVE       RGB(123, 125,   0)
-    #define ILI_COLOR_LIGHTGREY   RGB(198, 195, 198)
-    #define ILI_COLOR_DARKGREY    RGB(123, 125, 123)
-    #define ILI_COLOR_BLUE        RGB(0,     0, 255)
-    #define ILI_COLOR_GREEN       RGB(0,   255,   0)
-    #define ILI_COLOR_CYAN        RGB(0,   255, 255)
-    #define ILI_COLOR_RED         RGB(255,   0,   0)
-    #define ILI_COLOR_MAGENTA     RGB(255,   0, 255)
-    #define ILI_COLOR_YELLOW      RGB(255, 255,   0)
-    #define ILI_COLOR_WHITE       RGB(255, 255, 255)
-    #define ILI_COLOR_ORANGE      RGB(255, 165,   0)
-    #define ILI_COLOR_GREENYELLOW RGB(173, 255,  41)
-    #define ILI_COLOR_PINK        RGB(255, 130, 198)
+    #define	R_POS_BGR	0	// Red last bit position for BGR display
+    #define	G_POS_BGR	5 	// Green last bit position for BGR display
+    #define	B_POS_BGR   11	// Blue last bit position for BGR display
+
+    #define	BGR(R,G,B) \
+        (((uint16_t)(R >> 3) << R_POS_BRG) | \
+         ((uint16_t)(G >> 2) << G_POS_BGR) | \
+         ((uint16_t)(B >> 3) << B_POS_BGR))
+
+    #define ILI_COLOR_BLACK       BGR(0,     0,   0)
+    #define ILI_COLOR_NAVY        BGR(0,     0, 123)
+    #define ILI_COLOR_DARKGREEN   BGR(0,   125,   0)
+    #define ILI_COLOR_DARKCYAN    BGR(0,   125, 123)
+    #define ILI_COLOR_MAROON      BGR(123,   0,   0)
+    #define ILI_COLOR_PURPLE      BGR(123,   0, 123)
+    #define ILI_COLOR_OLIVE       BGR(123, 125,   0)
+    #define ILI_COLOR_LIGHTGREY   BGR(198, 195, 198)
+    #define ILI_COLOR_DARKGREY    BGR(123, 125, 123)
+    #define ILI_COLOR_BLUE        BGR(0,     0, 255)
+    #define ILI_COLOR_GREEN       BGR(0,   255,   0)
+    #define ILI_COLOR_CYAN        BGR(0,   255, 255)
+    #define ILI_COLOR_RED         BGR(255,   0,   0)
+    #define ILI_COLOR_MAGENTA     BGR(255,   0, 255)
+    #define ILI_COLOR_YELLOW      BGR(255, 255,   0)
+    #define ILI_COLOR_WHITE       BGR(255, 255, 255)
+    #define ILI_COLOR_ORANGE      BGR(255, 165,   0)
+    #define ILI_COLOR_GREENYELLOW BGR(173, 255,  41)
+    #define ILI_COLOR_PINK        BGR(255, 130, 198)
 #endif
 
 /*************************** Pin confirugation START ************************/
@@ -156,14 +168,14 @@ SOFTWARE.
 	* RDn					PB3
 	*/
 	#define ILI_PORT_DATA	GPIOA
-	#define DATA_0			GPIO0
-	#define DATA_1			GPIO1
-	#define DATA_2			GPIO2
-	#define DATA_3			GPIO3
-	#define DATA_4			GPIO4
-	#define DATA_5			GPIO5
-	#define DATA_6			GPIO6
-	#define DATA_7			GPIO7
+	#define ILI_D0  		GPIO0
+	#define ILI_D1  		GPIO1
+	#define ILI_D2          GPIO2
+	#define ILI_D3  		GPIO3
+	#define ILI_D4			GPIO4
+	#define ILI_D5			GPIO5
+	#define ILI_D6			GPIO6
+	#define ILI_D7			GPIO7
 	#define ILI_PORT_CTRL	GPIOB
 	#define ILI_RST			GPIO0
 	#define ILI_CS			GPIO1
@@ -174,14 +186,14 @@ SOFTWARE.
 
 #elif DSO138_PLATFORM
 	#define ILI_PORT_DATA	GPIOB
-	#define DATA_0			GPIO0
-	#define DATA_1			GPIO1
-	#define DATA_2			GPIO2
-	#define DATA_3			GPIO3
-	#define DATA_4			GPIO4
-	#define DATA_5			GPIO5
-	#define DATA_6			GPIO6
-	#define DATA_7			GPIO7
+	#define ILI_D0			GPIO0
+	#define ILI_D1			GPIO1
+	#define ILI_D2			GPIO2
+	#define ILI_D3			GPIO3
+	#define ILI_D4			GPIO4
+	#define ILI_D5			GPIO5
+	#define ILI_D6			GPIO6
+	#define ILI_D7			GPIO7
 	#define ILI_PORT_CTRL_B	GPIOB
 	#define ILI_RD			GPIO10
 	#define ILI_RST			GPIO11
@@ -248,7 +260,7 @@ AFIO_MAPR_SWJ_CFG_JTAG_OFF_SW_OFF: JTAG-DP disabled and SW-DP disabled
 											ILI_PORT_DATA, \
 											GPIO_MODE_OUTPUT_50_MHZ, \
 											GPIO_CNF_OUTPUT_PUSHPULL, \
-											DATA_0 | DATA_1 | DATA_2 | DATA_3 | DATA_4 | DATA_5 | DATA_6 | DATA_7); \
+											ILI_D0 | ILI_D1 | ILI_D2 | ILI_D3 | ILI_D4 | ILI_D5 | ILI_D6 | ILI_D7); \
 										/*Configure ILI_PORT_CTRL GPIO pins */ \
 										gpio_set_mode(ILI_PORT_CTRL, \
 											GPIO_MODE_OUTPUT_50_MHZ, \
@@ -257,7 +269,7 @@ AFIO_MAPR_SWJ_CFG_JTAG_OFF_SW_OFF: JTAG-DP disabled and SW-DP disabled
 										/*Configure GPIO pin Output Level */ \
 										gpio_set( \
 											ILI_PORT_DATA, \
-											DATA_0 | DATA_1 | DATA_2 | DATA_3 | DATA_4 | DATA_5 | DATA_6 | DATA_7); \
+											ILI_D0 | ILI_D1 | ILI_D2 | ILI_D3 | ILI_D4 | ILI_D5 | ILI_D6 | ILI_D7); \
 										gpio_set( \
 											ILI_PORT_CTRL, \
 											ILI_RST | ILI_CS | ILI_DC | ILI_WR | ILI_RD); \
@@ -277,7 +289,7 @@ AFIO_MAPR_SWJ_CFG_JTAG_OFF_SW_OFF: JTAG-DP disabled and SW-DP disabled
 											ILI_PORT_DATA, \
 											GPIO_MODE_OUTPUT_50_MHZ, \
 											GPIO_CNF_OUTPUT_PUSHPULL, \
-											DATA_0 | DATA_1 | DATA_2 | DATA_3 | DATA_4 | DATA_5 | DATA_6 | DATA_7); \
+											ILI_D0 | ILI_D1 | ILI_D2 | ILI_D3 | ILI_D4 | ILI_D5 | ILI_D6 | ILI_D7); \
 										/*Configure ILI_PORT_CTRL_B GPIO pins */ \
 										gpio_set_mode(ILI_PORT_CTRL_B, \
 											GPIO_MODE_OUTPUT_50_MHZ, \
@@ -291,7 +303,7 @@ AFIO_MAPR_SWJ_CFG_JTAG_OFF_SW_OFF: JTAG-DP disabled and SW-DP disabled
 										/*Configure GPIO pin Output Level */ \
 										gpio_set( \
 											ILI_PORT_DATA, \
-											DATA_0 | DATA_1 | DATA_2 | DATA_3 | DATA_4 | DATA_5 | DATA_6 | DATA_7); \
+											ILI_D0 | ILI_D1 | ILI_D2 | ILI_D3 | ILI_D4 | ILI_D5 | ILI_D6 | ILI_D7); \
 										gpio_set( \
 											ILI_PORT_CTRL_B, \
 											ILI_RD | ILI_RST); \

--- a/ili9341_stm32_parallel8.h
+++ b/ili9341_stm32_parallel8.h
@@ -109,8 +109,8 @@ SOFTWARE.
 #define ILI_COLOR_GREENYELLOW 0xAFE5  ///< 173, 255,  41
 #define ILI_COLOR_PINK        0xFC18  ///< 255, 130, 198
 
-/*************************** Pin confirugation START ************************
-/**
+/*************************** Pin confirugation START ************************/
+/*
  * Pin mapping:
  * ILI9341				STM32
  * ---------------------------

--- a/ili9341_stm32_parallel8.h
+++ b/ili9341_stm32_parallel8.h
@@ -109,7 +109,7 @@ SOFTWARE.
 #define ILI_COLOR_GREENYELLOW 0xAFE5  ///< 173, 255,  41
 #define ILI_COLOR_PINK        0xFC18  ///< 255, 130, 198
 
-
+/*************************** Pin confirugation START ************************
 /**
  * Pin mapping:
  * ILI9341				STM32
@@ -128,12 +128,30 @@ SOFTWARE.
  * RDn					PB3
  */
 #define ILI_PORT_DATA	GPIOA
+#define DATA_0			GPIO0
+#define DATA_1			GPIO1
+#define DATA_2			GPIO2
+#define DATA_3			GPIO3
+#define DATA_4			GPIO4
+#define DATA_5			GPIO5
+#define DATA_6			GPIO6
+#define DATA_7			GPIO7
 #define ILI_PORT_CTRL	GPIOB
 #define ILI_RST			GPIO0
 #define ILI_CS			GPIO1
 #define ILI_DC			GPIO5
 #define ILI_WR			GPIO4
 #define ILI_RD			GPIO3
+
+#define JTAG_REMAPPING_MODE		AFIO_MAPR_SWJ_CFG_FULL_SWJ_NO_JNTRST
+/*
+Possible values:
+AFIO_MAPR_SWJ_CFG_FULL_SWJ: Full Serial Wire JTAG capability
+AFIO_MAPR_SWJ_CFG_FULL_SWJ_NO_JNTRST:  Full Serial Wire JTAG capability without JNTRST (Configures PB4 as GPIO)
+AFIO_MAPR_SWJ_CFG_JTAG_OFF_SW_ON: JTAG-DP disabled with SW-DP enabled
+AFIO_MAPR_SWJ_CFG_JTAG_OFF_SW_OFF: JTAG-DP disabled and SW-DP disabled
+*/
+/******* Pin confirugation END (no changes are needed below this line) *******/
 
 #define RD_ACTIVE		GPIO_BRR(ILI_PORT_CTRL) = ILI_RD
 #define RD_IDLE			GPIO_BSRR(ILI_PORT_CTRL) = ILI_RD
@@ -158,15 +176,26 @@ SOFTWARE.
 									rcc_periph_clock_enable(RCC_AFIO); \
 								}
 #define CONFIG_GPIO()			{ \
-									/*Configure GPIO pins : PA0 PA1 PA2 PA3 PA4 PA5 PA6 PA7 */ \
-									gpio_set_mode(GPIOA, GPIO_MODE_OUTPUT_50_MHZ, GPIO_CNF_OUTPUT_PUSHPULL, GPIO0|GPIO1|GPIO2|GPIO3|GPIO4|GPIO5|GPIO6|GPIO7); \
-									/*Configure GPIO pins : PB0 PB1 PB3 PB4 PB5 PB8 */ \
-									gpio_set_mode(GPIOB, GPIO_MODE_OUTPUT_50_MHZ, GPIO_CNF_OUTPUT_PUSHPULL, GPIO0|GPIO1|GPIO3|GPIO4|GPIO5|GPIO8); \
+									/*Configure ILI_PORT_DATA GPIO pins */ \
+									gpio_set_mode( \
+										ILI_PORT_DATA, \
+										GPIO_MODE_OUTPUT_50_MHZ, \
+										GPIO_CNF_OUTPUT_PUSHPULL, \
+										DATA_0 | DATA_1 | DATA_2 | DATA_3 | DATA_4 | DATA_5 | DATA_6 | DATA_7); \
+									/*Configure ILI_PORT_CTRL GPIO pins */ \
+									gpio_set_mode(ILI_PORT_CTRL, \
+										GPIO_MODE_OUTPUT_50_MHZ, \
+										GPIO_CNF_OUTPUT_PUSHPULL, \
+										ILI_RST | ILI_CS | ILI_DC | ILI_WR | ILI_RD); \
 									/*Configure GPIO pin Output Level */ \
-									gpio_set(GPIOA, GPIO0|GPIO1|GPIO2|GPIO3|GPIO4|GPIO5|GPIO6|GPIO7); \
-									gpio_set(GPIOB, GPIO0|GPIO1|GPIO3|GPIO4|GPIO5|GPIO8); \
-									/* Configures PB4 as GPIO */ \
-									AFIO_MAPR |= AFIO_MAPR_SWJ_CFG_FULL_SWJ_NO_JNTRST; \
+									gpio_set( \
+										ILI_PORT_DATA, \
+										DATA_0 | DATA_1 | DATA_2 | DATA_3 | DATA_4 | DATA_5 | DATA_6 | DATA_7); \
+									gpio_set( \
+										ILI_PORT_CTRL, \
+										ILI_RST | ILI_CS | ILI_DC | ILI_WR | ILI_RD); \
+									/* Remap JTAG pins */ \
+									AFIO_MAPR |= JTAG_REMAPPING_MODE; \
 								}
 
 #define SWAP(a, b)		{uint16_t temp; temp = a; a = b; b = temp;}

--- a/ili9341_stm32_parallel8.h
+++ b/ili9341_stm32_parallel8.h
@@ -87,7 +87,6 @@ SOFTWARE.
 #define ILI_PWCTR6  0xFC
 */
 
-
 // Color definitions
 #define ILI_COLOR_BLACK       0x0000  ///<   0,   0,   0
 #define ILI_COLOR_NAVY        0x000F  ///<   0,   0, 123
@@ -110,64 +109,98 @@ SOFTWARE.
 #define ILI_COLOR_PINK        0xFC18  ///< 255, 130, 198
 
 /*************************** Pin confirugation START ************************/
-/*
- * Pin mapping:
- * ILI9341				STM32
- * ---------------------------
-* 		--Data--
- * DB10					PA0
- * DB11					PA1
- * ..					..
- * DB17					PA7
- *
- *		--Control--
- * RESETn				PB0
- * CSn					PB1
- * D/Cn					PB5#include <libopencm3/stm32/rcc.h>
- * WRn					PB4
- * RDn					PB3
- *
- * >>>>>>>>>>>> ATTENTION: if there are other ports in use, e.g. GPIOC,
- * >>>>>>>>>>>> please, update CONFIG_GPIO_CLOCK() and CONFIG_GPIO()
- * >>>>>>>>>>>> macros below accordingly.
- */
-#define ILI_PORT_DATA	GPIOA
-#define DATA_0			GPIO0
-#define DATA_1			GPIO1
-#define DATA_2			GPIO2
-#define DATA_3			GPIO3
-#define DATA_4			GPIO4
-#define DATA_5			GPIO5
-#define DATA_6			GPIO6
-#define DATA_7			GPIO7
-#define ILI_PORT_CTRL	GPIOB
-#define ILI_RST			GPIO0
-#define ILI_CS			GPIO1
-#define ILI_DC			GPIO5
-#define ILI_WR			GPIO4
-#define ILI_RD			GPIO3
+#ifdef USER_DEFAULT_PLATFORM
+	/*
+	* Pin mapping:
+	* ILI9341				STM32
+	* ---------------------------
+	* 		--Data--
+	* DB10					PA0
+	* DB11					PA1
+	* ..					..
+	* DB17					PA7
+	*
+	*		--Control--
+	* RESETn				PB0
+	* CSn					PB1
+	* D/Cn					PB5#include <libopencm3/stm32/rcc.h>
+	* WRn					PB4
+	* RDn					PB3
+	*/
+	#define ILI_PORT_DATA	GPIOA
+	#define DATA_0			GPIO0
+	#define DATA_1			GPIO1
+	#define DATA_2			GPIO2
+	#define DATA_3			GPIO3
+	#define DATA_4			GPIO4
+	#define DATA_5			GPIO5
+	#define DATA_6			GPIO6
+	#define DATA_7			GPIO7
+	#define ILI_PORT_CTRL	GPIOB
+	#define ILI_RST			GPIO0
+	#define ILI_CS			GPIO1
+	#define ILI_DC			GPIO5
+	#define ILI_WR			GPIO4
+	#define ILI_RD			GPIO3
+	#define JTAG_REMAPPING_MODE AFIO_MAPR_SWJ_CFG_FULL_SWJ_NO_JNTRST /* See below */
 
-#define JTAG_REMAPPING_MODE		AFIO_MAPR_SWJ_CFG_FULL_SWJ_NO_JNTRST
+#elif DSO138_PLATFORM
+	#define ILI_PORT_DATA	GPIOB
+	#define DATA_0			GPIO0
+	#define DATA_1			GPIO1
+	#define DATA_2			GPIO2
+	#define DATA_3			GPIO3
+	#define DATA_4			GPIO4
+	#define DATA_5			GPIO5
+	#define DATA_6			GPIO6
+	#define DATA_7			GPIO7
+	#define ILI_PORT_CTRL_B	GPIOB
+	#define ILI_RD			GPIO10
+	#define ILI_RST			GPIO11
+	#define ILI_PORT_CTRL_C	GPIOC
+	#define ILI_CS			GPIO13
+	#define ILI_DC			GPIO14
+	#define ILI_WR			GPIO15
+	#define JTAG_REMAPPING_MODE AFIO_MAPR_SWJ_CFG_JTAG_OFF_SW_OFF /* See below */
+#endif
 /*
-Possible values:
+Possible values of JTAG_REMAPPING_MODE:
 AFIO_MAPR_SWJ_CFG_FULL_SWJ: Full Serial Wire JTAG capability
-AFIO_MAPR_SWJ_CFG_FULL_SWJ_NO_JNTRST:  Full Serial Wire JTAG capability without JNTRST (Configures PB4 as GPIO)
+AFIO_MAPR_SWJ_CFG_FULL_SWJ_NO_JNTRST: Full Serial Wire JTAG capability without JNTRST (PB4 as GPIO)
 AFIO_MAPR_SWJ_CFG_JTAG_OFF_SW_ON: JTAG-DP disabled with SW-DP enabled
 AFIO_MAPR_SWJ_CFG_JTAG_OFF_SW_OFF: JTAG-DP disabled and SW-DP disabled
 */
 
-/******* Pin confirugation END (no changes are needed below this line) *******/
+/*
+ * >>>>>> ATTENTION: if there are other ports in use, e.g. GPIOC, <<<<<<
+ * >>>>>>   please, update CONFIG_GPIO_CLOCK() and CONFIG_GPIO()  <<<<<<
+ * >>>>>>              macros below accordingly.                  <<<<<<
+ */
+/*************************** Pin confirugation END ************************/
 
-#define RD_ACTIVE		GPIO_BRR(ILI_PORT_CTRL) = ILI_RD
-#define RD_IDLE			GPIO_BSRR(ILI_PORT_CTRL) = ILI_RD
-#define WR_ACTIVE		GPIO_BRR(ILI_PORT_CTRL) = ILI_WR
-#define WR_IDLE			GPIO_BSRR(ILI_PORT_CTRL) = ILI_WR
-#define DC_CMD			GPIO_BRR(ILI_PORT_CTRL) = ILI_DC
-#define DC_DAT			GPIO_BSRR(ILI_PORT_CTRL) = ILI_DC
-#define CS_ACTIVE		GPIO_BRR(ILI_PORT_CTRL) = ILI_CS
-#define CS_IDLE			GPIO_BSRR(ILI_PORT_CTRL) = ILI_CS
-#define RST_ACTIVE		GPIO_BRR(ILI_PORT_CTRL) = ILI_RST
-#define RST_IDLE		GPIO_BSRR(ILI_PORT_CTRL) = ILI_RST
+#ifdef USER_DEFAULT_PLATFORM
+	#define RD_ACTIVE		GPIO_BRR(ILI_PORT_CTRL) = ILI_RD
+	#define RD_IDLE			GPIO_BSRR(ILI_PORT_CTRL) = ILI_RD
+	#define WR_ACTIVE		GPIO_BRR(ILI_PORT_CTRL) = ILI_WR
+	#define WR_IDLE			GPIO_BSRR(ILI_PORT_CTRL) = ILI_WR
+	#define DC_CMD			GPIO_BRR(ILI_PORT_CTRL) = ILI_DC
+	#define DC_DAT			GPIO_BSRR(ILI_PORT_CTRL) = ILI_DC
+	#define CS_ACTIVE		GPIO_BRR(ILI_PORT_CTRL) = ILI_CS
+	#define CS_IDLE			GPIO_BSRR(ILI_PORT_CTRL) = ILI_CS
+	#define RST_ACTIVE		GPIO_BRR(ILI_PORT_CTRL) = ILI_RST
+	#define RST_IDLE		GPIO_BSRR(ILI_PORT_CTRL) = ILI_RST
+#elif DSO138_PLATFORM
+	#define RD_ACTIVE		GPIO_BRR(ILI_PORT_CTRL_B) = ILI_RD
+	#define RD_IDLE			GPIO_BSRR(ILI_PORT_CTRL_B) = ILI_RD
+	#define WR_ACTIVE		GPIO_BRR(ILI_PORT_CTRL_C) = ILI_WR
+	#define WR_IDLE			GPIO_BSRR(ILI_PORT_CTRL_C) = ILI_WR
+	#define DC_CMD			GPIO_BRR(ILI_PORT_CTRL_C) = ILI_DC
+	#define DC_DAT			GPIO_BSRR(ILI_PORT_CTRL_C) = ILI_DC
+	#define CS_ACTIVE		GPIO_BRR(ILI_PORT_CTRL_C) = ILI_CS
+	#define CS_IDLE			GPIO_BSRR(ILI_PORT_CTRL_C) = ILI_CS
+	#define RST_ACTIVE		GPIO_BRR(ILI_PORT_CTRL_B) = ILI_RST
+	#define RST_IDLE		GPIO_BSRR(ILI_PORT_CTRL_B) = ILI_RST
+#endif
 
 #define WR_STROBE		{WR_ACTIVE; WR_IDLE;}
 #define RD_STROBE		{RD_ACTIVE; RD_IDLE;}
@@ -175,33 +208,72 @@ AFIO_MAPR_SWJ_CFG_JTAG_OFF_SW_OFF: JTAG-DP disabled and SW-DP disabled
 #define WRITE_8BIT(d)	{GPIO_BSRR(ILI_PORT_DATA) = (uint32_t)(0x00FF0000 | ((d) & 0xFF)); WR_STROBE;}
 #define READ_8BIT(d)	{d = (uint8_t)(GPIO_IDR(ILI_PORT_DATA) & 0x00FF;}
 
-#define CONFIG_GPIO_CLOCK()	    { \
-									rcc_periph_clock_enable(RCC_GPIOB); \
-									rcc_periph_clock_enable(RCC_GPIOA); \
-									rcc_periph_clock_enable(RCC_AFIO); \
-								}
-#define CONFIG_GPIO()			{ \
-									/*Configure ILI_PORT_DATA GPIO pins */ \
-									gpio_set_mode( \
-										ILI_PORT_DATA, \
-										GPIO_MODE_OUTPUT_50_MHZ, \
-										GPIO_CNF_OUTPUT_PUSHPULL, \
-										DATA_0 | DATA_1 | DATA_2 | DATA_3 | DATA_4 | DATA_5 | DATA_6 | DATA_7); \
-									/*Configure ILI_PORT_CTRL GPIO pins */ \
-									gpio_set_mode(ILI_PORT_CTRL, \
-										GPIO_MODE_OUTPUT_50_MHZ, \
-										GPIO_CNF_OUTPUT_PUSHPULL, \
-										ILI_RST | ILI_CS | ILI_DC | ILI_WR | ILI_RD); \
-									/*Configure GPIO pin Output Level */ \
-									gpio_set( \
-										ILI_PORT_DATA, \
-										DATA_0 | DATA_1 | DATA_2 | DATA_3 | DATA_4 | DATA_5 | DATA_6 | DATA_7); \
-									gpio_set( \
-										ILI_PORT_CTRL, \
-										ILI_RST | ILI_CS | ILI_DC | ILI_WR | ILI_RD); \
-									/* Remap JTAG pins */ \
-									AFIO_MAPR |= JTAG_REMAPPING_MODE; \
-								}
+#ifdef USER_DEFAULT_PLATFORM
+	#define CONFIG_GPIO_CLOCK()	    { \
+										rcc_periph_clock_enable(RCC_GPIOB); \
+										rcc_periph_clock_enable(RCC_GPIOA); \
+										rcc_periph_clock_enable(RCC_AFIO); \
+									}
+	#define CONFIG_GPIO()			{ \
+										/*Configure ILI_PORT_DATA GPIO pins */ \
+										gpio_set_mode( \
+											ILI_PORT_DATA, \
+											GPIO_MODE_OUTPUT_50_MHZ, \
+											GPIO_CNF_OUTPUT_PUSHPULL, \
+											DATA_0 | DATA_1 | DATA_2 | DATA_3 | DATA_4 | DATA_5 | DATA_6 | DATA_7); \
+										/*Configure ILI_PORT_CTRL GPIO pins */ \
+										gpio_set_mode(ILI_PORT_CTRL, \
+											GPIO_MODE_OUTPUT_50_MHZ, \
+											GPIO_CNF_OUTPUT_PUSHPULL, \
+											ILI_RST | ILI_CS | ILI_DC | ILI_WR | ILI_RD); \
+										/*Configure GPIO pin Output Level */ \
+										gpio_set( \
+											ILI_PORT_DATA, \
+											DATA_0 | DATA_1 | DATA_2 | DATA_3 | DATA_4 | DATA_5 | DATA_6 | DATA_7); \
+										gpio_set( \
+											ILI_PORT_CTRL, \
+											ILI_RST | ILI_CS | ILI_DC | ILI_WR | ILI_RD); \
+										/* Remap JTAG pins */ \
+										AFIO_MAPR |= JTAG_REMAPPING_MODE; \
+									}
+#elif DSO138_PLATFORM
+	#define CONFIG_GPIO_CLOCK()	    { \
+										rcc_periph_clock_enable(RCC_GPIOB); \
+										rcc_periph_clock_enable(RCC_GPIOA); \
+										rcc_periph_clock_enable(RCC_GPIOC); \
+										rcc_periph_clock_enable(RCC_AFIO); \
+									}
+	#define CONFIG_GPIO()			{ \
+										/*Configure ILI_PORT_DATA GPIO pins */ \
+										gpio_set_mode( \
+											ILI_PORT_DATA, \
+											GPIO_MODE_OUTPUT_50_MHZ, \
+											GPIO_CNF_OUTPUT_PUSHPULL, \
+											DATA_0 | DATA_1 | DATA_2 | DATA_3 | DATA_4 | DATA_5 | DATA_6 | DATA_7); \
+										/*Configure ILI_PORT_CTRL_B GPIO pins */ \
+										gpio_set_mode(ILI_PORT_CTRL_B, \
+											GPIO_MODE_OUTPUT_50_MHZ, \
+											GPIO_CNF_OUTPUT_PUSHPULL, \
+											ILI_RD | ILI_RST); \
+										/*Configure ILI_PORT_CTRL_C GPIO pins */ \
+										gpio_set_mode(ILI_PORT_CTRL_C, \
+											GPIO_MODE_OUTPUT_50_MHZ, \
+											GPIO_CNF_OUTPUT_PUSHPULL, \
+											ILI_CS | ILI_DC | ILI_WR); \
+										/*Configure GPIO pin Output Level */ \
+										gpio_set( \
+											ILI_PORT_DATA, \
+											DATA_0 | DATA_1 | DATA_2 | DATA_3 | DATA_4 | DATA_5 | DATA_6 | DATA_7); \
+										gpio_set( \
+											ILI_PORT_CTRL_B, \
+											ILI_RD | ILI_RST); \
+										gpio_set( \
+											ILI_PORT_CTRL_C, \
+											ILI_CS | ILI_DC | ILI_WR); \
+										/* Remap JTAG pins */ \
+										AFIO_MAPR |= JTAG_REMAPPING_MODE; \
+									}
+#endif
 
 #define SWAP(a, b)		{uint16_t temp; temp = a; a = b; b = temp;}
 

--- a/ili9341_stm32_parallel8.h
+++ b/ili9341_stm32_parallel8.h
@@ -110,21 +110,22 @@ SOFTWARE.
     #define ILI_COLOR_PINK        0xFC18  ///< 255, 130, 198
 
 #elif DSO138_PLATFORM
-    #define	R_POS_RGB	11	// Red last bit position for RGB display
-    #define	G_POS_RGB	5 	// Green last bit position for RGB display
+    #define	R_POS_RGB   11	// Red last bit position for RGB display
+    #define	G_POS_RGB   5 	// Green last bit position for RGB display
     #define	B_POS_RGB   0	// Blue last bit position for RGB display
-    #define	RGB(R,G,B) \
-        (((uint16_t)(R >> 3) << R_POS_RGB) | \
-         ((uint16_t)(G >> 2) << G_POS_RGB) | \
-         ((uint16_t)(B >> 3) << B_POS_RGB))
 
-    #define	R_POS_BGR	0	// Red last bit position for BGR display
-    #define	G_POS_BGR	5 	// Green last bit position for BGR display
+    #define	RGB(R,G,B) \
+	(((uint16_t)(R >> 3) << R_POS_RGB) | \
+	 ((uint16_t)(G >> 2) << G_POS_RGB) | \
+	 ((uint16_t)(B >> 3) << B_POS_RGB))
+
+    #define	R_POS_BGR   0	// Red last bit position for BGR display
+    #define	G_POS_BGR   5 	// Green last bit position for BGR display
     #define	B_POS_BGR   11	// Blue last bit position for BGR display
 
     #define	BGR(R,G,B) \
-        (((uint16_t)(R >> 3) << R_POS_BRG) | \
-         ((uint16_t)(G >> 2) << G_POS_BGR) | \
+	(((uint16_t)(R >> 3) << R_POS_BGR) | \
+	 ((uint16_t)(G >> 2) << G_POS_BGR) | \
          ((uint16_t)(B >> 3) << B_POS_BGR))
 
     #define ILI_COLOR_BLACK       BGR(0,     0,   0)


### PR DESCRIPTION
Hello,
the PR is about adding a support of different target platforms, e.g. DSO138, a well known simple DIY oscilloscope. 
The target platform is selected by compilation flag in a Makefile:
```
################ Target Platform Flags (uncomment one) ######################
CFLAGS += -DUSER_DEFAULT_PLATFORM		# Default example from the repository
#CFLAGS += -DDSO138_PLATFORM		    # DSO138 oscilloscope (jyetech.com/dso-138-oscilloscope-diy-kit/)
```
Also some small modifications have been added, e.g. `make` does not call st-flash utility by default, etc. 

A demo is running on a DSO138 oscilloscope:
![dso138_example](https://user-images.githubusercontent.com/5597505/91482339-95004d80-e8ae-11ea-9b50-a7d1a88100a4.jpg)

